### PR TITLE
Fixed client.go - Heartbeat Packet Length

### DIFF
--- a/soupbintcp/client.go
+++ b/soupbintcp/client.go
@@ -148,7 +148,7 @@ func (c *Client) runHeartbeat() {
 func (c *Client) sendHeartbeat() {
 	request := HeartbeatPacket{
 		Header: Header{
-			Length: [2]byte{0, 3},
+			Length: [2]byte{0, 1},
 			Type:   PacketClientHeartbeat,
 		},
 	}


### PR DESCRIPTION
Fixed HeartBeat Packet Length. it should be 1, not 3. Tested on real exchange staging